### PR TITLE
Implement record sorting and make filters/sorting cumulative

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -8,7 +8,7 @@ android {
     compileSdkVersion 28
     defaultConfig {
         applicationId "com.dmonzonis.nookpendium"
-        minSdkVersion 15
+        minSdkVersion 21
         targetSdkVersion 28
         versionCode 1
         versionName "1.0"

--- a/app/src/main/java/com/dmonzonis/nookpendium/CollectionActivity.kt
+++ b/app/src/main/java/com/dmonzonis/nookpendium/CollectionActivity.kt
@@ -4,6 +4,7 @@ import android.os.Bundle
 import android.view.MenuItem
 import androidx.appcompat.app.ActionBarDrawerToggle
 import androidx.appcompat.app.AppCompatActivity
+import androidx.fragment.app.DialogFragment
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.google.android.material.tabs.TabLayout
@@ -12,7 +13,7 @@ import kotlinx.android.synthetic.main.filter_fab_submenu.*
 import java.io.InputStream
 import java.util.*
 
-class CollectionActivity : AppCompatActivity() {
+class CollectionActivity : AppCompatActivity(), SortDialogFragment.SortDialogListener {
     private lateinit var viewAdapter: RecordListAdapter
     private lateinit var viewManager: RecyclerView.LayoutManager
     lateinit var drawerToggle: ActionBarDrawerToggle
@@ -66,6 +67,14 @@ class CollectionActivity : AppCompatActivity() {
         setFilterButtonsEnabled(false)
         fabFilterThisMonth.setOnClickListener { filterByThisMonth() }
         fabFilterClear.setOnClickListener { updateRecyclerView(recordset.records) }
+        fabSortBy.setOnClickListener {
+            val sortByDialog = SortDialogFragment()
+            sortByDialog.show(supportFragmentManager, "sort_by")
+        }
+    }
+
+    override fun onDialogPositiveClick(dialog: DialogFragment, token: String, descending: Boolean) {
+        updateRecyclerView(recordset.sorted(token, descending))
     }
 
     private fun updateRecyclerView(records: List<Record>) {
@@ -76,17 +85,20 @@ class CollectionActivity : AppCompatActivity() {
     private fun setFilterButtonsEnabled(enabled: Boolean) {
         fabFilterThisMonth.isEnabled = enabled
         fabFilterClear.isEnabled = enabled
+        fabSortBy.isEnabled = enabled
     }
 
     private fun toggleFilterSubmenuVisibility() {
         if (isFilterSubmenuOpen) {
             layoutFilterThisMonth.animate().alpha(0.0f)
             layoutFilterClear.animate().alpha(0.0f)
+            layoutSortBy.animate().alpha(0.0f)
             setFilterButtonsEnabled(false)
             fabFilters.setImageResource(R.drawable.ic_search_black_24dp)
         } else {
             layoutFilterThisMonth.animate().alpha(1.0f)
             layoutFilterClear.animate().alpha(1.0f)
+            layoutSortBy.animate().alpha(1.0f)
             setFilterButtonsEnabled(true)
             fabFilters.setImageResource(R.drawable.ic_clear_black_24dp)
         }

--- a/app/src/main/java/com/dmonzonis/nookpendium/CollectionActivity.kt
+++ b/app/src/main/java/com/dmonzonis/nookpendium/CollectionActivity.kt
@@ -66,7 +66,10 @@ class CollectionActivity : AppCompatActivity(), SortDialogFragment.SortDialogLis
         fabFilters.setOnClickListener { toggleFilterSubmenuVisibility() }
         setFilterButtonsEnabled(false)
         fabFilterThisMonth.setOnClickListener { filterByThisMonth() }
-        fabFilterClear.setOnClickListener { updateRecyclerView(recordset.records) }
+        fabFilterClear.setOnClickListener {
+            recordset.restore()
+            updateRecyclerView(recordset.records)
+        }
         fabSortBy.setOnClickListener {
             val sortByDialog = SortDialogFragment()
             sortByDialog.show(supportFragmentManager, "sort_by")
@@ -74,7 +77,7 @@ class CollectionActivity : AppCompatActivity(), SortDialogFragment.SortDialogLis
     }
 
     override fun onDialogPositiveClick(dialog: DialogFragment, token: String, descending: Boolean) {
-        updateRecyclerView(recordset.sorted(token, descending))
+        updateRecyclerView(recordset.applySort(token, descending))
     }
 
     private fun updateRecyclerView(records: List<Record>) {
@@ -107,7 +110,7 @@ class CollectionActivity : AppCompatActivity(), SortDialogFragment.SortDialogLis
 
     private fun filterByThisMonth() {
         val currentMonth = Calendar.getInstance().get(Calendar.MONTH)
-        val records = recordset.filterByMonth(currentMonth)
+        val records = recordset.applyFilterByMonth(currentMonth)
         updateRecyclerView(records)
     }
 

--- a/app/src/main/java/com/dmonzonis/nookpendium/Record.kt
+++ b/app/src/main/java/com/dmonzonis/nookpendium/Record.kt
@@ -9,7 +9,7 @@ import java.io.InputStream
 data class Record(
     val id: String,
     val name: String,
-    val price: String,
+    val price: Int?,
     val time: String,
     val location: String,
     val shadowSize: Int?,
@@ -25,6 +25,22 @@ class Recordset(val records: List<Record>) {
 
     fun filterByMonth(month: Int): List<Record> {
         return filter { month < it.availability.size && it.availability[month] == 1 }
+    }
+
+    fun sorted(field: String, descending: Boolean): List<Record> {
+        return when (field) {
+            "name" -> if (descending) {
+                records.sortedByDescending { it.name }
+            } else {
+                records.sortedBy { it.name }
+            }
+            // Sort by price by default
+            else -> if (descending) {
+                records.sortedByDescending { it.price }
+            } else {
+                records.sortedBy { it.price }
+            }
+        }
     }
 }
 
@@ -61,7 +77,7 @@ class RecordXmlParser(private val context: Context) {
         var id = ""
         var name = ""
         var imageFilename = ""
-        var price = ""
+        var price: Int? = null
         var time = ""
         var location = ""
         var shadowSize: Int? = null
@@ -76,7 +92,7 @@ class RecordXmlParser(private val context: Context) {
             when (parser.name) {
                 "id" -> id = readText(parser)
                 "name" -> name = readText(parser)
-                "price" -> price = readText(parser)
+                "price" -> price = readText(parser).toIntOrNull()
                 "time" -> time = readText(parser)
                 "location" -> location = readText(parser)
                 "shadow_size" -> shadowSize = readText(parser).toIntOrNull()

--- a/app/src/main/java/com/dmonzonis/nookpendium/Record.kt
+++ b/app/src/main/java/com/dmonzonis/nookpendium/Record.kt
@@ -18,17 +18,21 @@ data class Record(
     var captured: Boolean?
 )
 
-class Recordset(val records: List<Record>) {
-    fun filter(filter: (r: Record) -> Boolean): List<Record> {
-        return records.filter(filter)
+class Recordset(private val totalRecords: List<Record>) {
+    // Current subset of records after having applied filters/sorting
+    var records = totalRecords
+
+    fun applyFilter(filter: (r: Record) -> Boolean): List<Record> {
+        records = records.filter(filter)
+        return records
     }
 
-    fun filterByMonth(month: Int): List<Record> {
-        return filter { month < it.availability.size && it.availability[month] == 1 }
+    fun applyFilterByMonth(month: Int): List<Record> {
+        return applyFilter { month < it.availability.size && it.availability[month] == 1 }
     }
 
-    fun sorted(field: String, descending: Boolean): List<Record> {
-        return when (field) {
+    fun applySort(field: String, descending: Boolean): List<Record> {
+        records = when (field) {
             "name" -> if (descending) {
                 records.sortedByDescending { it.name }
             } else {
@@ -41,6 +45,12 @@ class Recordset(val records: List<Record>) {
                 records.sortedBy { it.price }
             }
         }
+        return records
+    }
+
+    // Removes all filters and sorting applied to the recordset
+    fun restore() {
+        records = totalRecords
     }
 }
 

--- a/app/src/main/java/com/dmonzonis/nookpendium/RecordListAdapter.kt
+++ b/app/src/main/java/com/dmonzonis/nookpendium/RecordListAdapter.kt
@@ -33,7 +33,7 @@ class RecordListAdapter(private val records: List<Record>) :
     override fun onBindViewHolder(holder: RecordHolder, position: Int) {
         val record: Record = records[position]
         holder.itemView.text_name.text = record.name
-        holder.itemView.text_price.text = record.price
+        holder.itemView.text_price.text = record.price?.toString() ?: "?"
         holder.itemView.img_picture.setImageResource(record.imageId)
 
         // Get captured state from shared preferences if it hasn't been loaded yet

--- a/app/src/main/java/com/dmonzonis/nookpendium/SortDialog.kt
+++ b/app/src/main/java/com/dmonzonis/nookpendium/SortDialog.kt
@@ -1,0 +1,49 @@
+package com.dmonzonis.nookpendium
+
+import android.app.AlertDialog
+import android.app.Dialog
+import android.content.Context
+import android.content.DialogInterface
+import android.os.Bundle
+import android.view.LayoutInflater
+import androidx.fragment.app.DialogFragment
+import kotlinx.android.synthetic.main.sort_by_dialog.view.*
+
+class SortDialogFragment : DialogFragment() {
+    // Instance of the interface that will deliver action events
+    private lateinit var listener: SortDialogListener
+
+    // The activity calling this dialog must implement this interface to be able to
+    // receive event callbacks
+    interface SortDialogListener {
+        fun onDialogPositiveClick(dialog: DialogFragment, token: String, descending: Boolean)
+    }
+
+    override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
+        return activity!!.let {
+            val dialogView = LayoutInflater.from(context).inflate(R.layout.sort_by_dialog, null)
+            val builder = AlertDialog.Builder(it)
+                .setView(dialogView)
+                .setPositiveButton(R.string.sort, DialogInterface.OnClickListener { dialog, id ->
+                    val token = when (dialogView.rgSortBy.checkedRadioButtonId) {
+                        dialogView.rbSortByName.id -> "name"
+                        else -> "price"
+                    }
+                    val descending =
+                        dialogView.rgSortOrder.checkedRadioButtonId == dialogView.rbOrderDescending.id
+                    listener.onDialogPositiveClick(this, token, descending)
+                })
+            builder.create()
+        }
+    }
+
+    override fun onAttach(context: Context) {
+        super.onAttach(context)
+        try {
+            listener = context as SortDialogListener
+        } catch (e: ClassCastException) {
+            // The activity opening this dialog must implement the listener interface
+            throw ClassCastException((context.toString() + " must implement SortDialogListener"))
+        }
+    }
+}

--- a/app/src/main/res/drawable/ic_sort_by_alpha_24px.xml
+++ b/app/src/main/res/drawable/ic_sort_by_alpha_24px.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:fillColor="#FF000000"
+      android:pathData="M14.94,4.66h-4.72l2.36,-2.36zM10.25,19.37h4.66l-2.33,2.33zM6.1,6.27L1.6,17.73h1.84l0.92,-2.45h5.11l0.92,2.45h1.84L7.74,6.27L6.1,6.27zM4.97,13.64l1.94,-5.18 1.94,5.18L4.97,13.64zM15.73,16.14h6.12v1.59h-8.53v-1.29l5.92,-8.56h-5.88v-1.6h8.3v1.26l-5.93,8.6z"/>
+</vector>

--- a/app/src/main/res/layout/filter_fab_submenu.xml
+++ b/app/src/main/res/layout/filter_fab_submenu.xml
@@ -7,12 +7,47 @@
     android:orientation="vertical">
 
     <LinearLayout
-        android:id="@+id/layoutFilterThisMonth"
+        android:id="@+id/layoutSortBy"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_gravity="bottom|end"
         android:layout_marginRight="18dp"
         android:layout_marginBottom="85dp"
+        android:alpha="0.0"
+        android:gravity="center_vertical"
+        android:orientation="horizontal">
+
+        <androidx.cardview.widget.CardView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center_vertical"
+            android:layout_marginRight="10dp">
+
+            <TextView
+                android:id="@+id/textSortBy"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:gravity="center"
+                android:padding="4dp"
+                android:text="@string/sortBy" />
+        </androidx.cardview.widget.CardView>
+
+        <com.google.android.material.floatingactionbutton.FloatingActionButton
+            android:id="@+id/fabSortBy"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:src="@drawable/ic_sort_by_alpha_24px"
+            app:fabSize="mini" />
+
+    </LinearLayout>
+
+    <LinearLayout
+        android:id="@+id/layoutFilterThisMonth"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="bottom|end"
+        android:layout_marginRight="18dp"
+        android:layout_marginBottom="135dp"
         android:alpha="0.0"
         android:gravity="center_vertical"
         android:orientation="horizontal">
@@ -47,7 +82,7 @@
         android:layout_height="wrap_content"
         android:layout_gravity="bottom|end"
         android:layout_marginRight="18dp"
-        android:layout_marginBottom="135dp"
+        android:layout_marginBottom="185dp"
         android:alpha="0.0"
         android:gravity="center_vertical"
         android:orientation="horizontal">

--- a/app/src/main/res/layout/sort_by_dialog.xml
+++ b/app/src/main/res/layout/sort_by_dialog.xml
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="250dp"
+    android:layout_height="wrap_content"
+    android:layout_gravity="center"
+    android:orientation="vertical"
+    android:paddingHorizontal="10dp"
+    android:paddingTop="10dp">
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/sortBy"
+        android:textSize="18sp"
+        android:textStyle="bold" />
+
+    <RadioGroup
+        android:id="@+id/rgSortBy"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_margin="5dp"
+        android:checkedButton="@id/rbSortByName"
+        android:orientation="vertical">
+
+        <RadioButton
+            android:id="@+id/rbSortByName"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginVertical="3dp"
+            android:text="@string/name" />
+
+        <RadioButton
+            android:id="@+id/rbSortByPrice"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginVertical="3dp"
+            android:text="@string/price" />
+    </RadioGroup>
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="12dp"
+        android:text="@string/order"
+        android:textSize="18sp"
+        android:textStyle="bold" />
+
+    <RadioGroup
+        android:id="@+id/rgSortOrder"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_marginHorizontal="5dp"
+        android:layout_marginTop="5dp"
+        android:layout_weight="1"
+        android:checkedButton="@id/rbOrderAscending"
+        android:orientation="horizontal">
+
+        <RadioButton
+            android:id="@+id/rbOrderAscending"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginVertical="3dp"
+            android:layout_weight="0.5"
+            android:text="@string/ascending" />
+
+        <RadioButton
+            android:id="@+id/rbOrderDescending"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginVertical="3dp"
+            android:layout_weight="0.5"
+            android:text="@string/descending" />
+    </RadioGroup>
+</LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -17,4 +17,12 @@
     <string name="filters">Filters</string>
     <string name="filterThisMonth">Show available this month</string>
     <string name="filterClear">Clear all filters</string>
+    <string name="sortBy">Sort by...</string>
+    <string name="sortByMessage">Select field to sort by</string>
+    <string name="name">Name</string>
+    <string name="price">Price</string>
+    <string name="order">Order</string>
+    <string name="ascending">Ascending</string>
+    <string name="descending">Descending</string>
+    <string name="sort">Sort</string>
 </resources>


### PR DESCRIPTION
Add a new floating button in the same submenu as the filters with a 'Sort by...' option. When clicked, a dialog will open letting the user choose what they want to sort by, and the order.

For now, sorting, as well as filters, are not persistent between recordsets, meaning that changing to a different recordset (e.g. from fish to bugs) will clear all filters and sorting options.

Also, filters and sorting are now applied to the currently shown recordset. This means that if we sort by price, and then filter by month, we will get the filtered results already sorted. If we then filter by name, we will filter on the already filtered results instead of the entire recordset.

Closes #6 