### PR TITLE
Remember last game used

### DIFF
--- a/app/src/main/java/com/dmonzonis/nookpendium/CollectionActivity.kt
+++ b/app/src/main/java/com/dmonzonis/nookpendium/CollectionActivity.kt
@@ -1,5 +1,7 @@
 package com.dmonzonis.nookpendium
 
+import android.content.Context
+import android.content.SharedPreferences
 import android.os.Bundle
 import android.view.MenuItem
 import android.view.View
@@ -17,10 +19,11 @@ import java.util.*
 class CollectionActivity : AppCompatActivity(), SortDialogFragment.SortDialogListener {
     private lateinit var viewAdapter: RecordListAdapter
     private lateinit var viewManager: RecyclerView.LayoutManager
-    lateinit var drawerToggle: ActionBarDrawerToggle
+    private lateinit var drawerToggle: ActionBarDrawerToggle
     private var selectedGame: Int = R.string.game_acnh
-    lateinit var recordset: Recordset
+    private lateinit var recordset: Recordset
     private var isFilterSubmenuOpen = false
+    private lateinit var sharedPrefs: SharedPreferences
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -50,7 +53,9 @@ class CollectionActivity : AppCompatActivity(), SortDialogFragment.SortDialogLis
         recyclerView.layoutManager = viewManager
         recyclerView.adapter = viewAdapter
 
-        // Load default game assets (Fish, ACNH)
+        // Load default game assets (Fish) for the last used game (or ACNH if no last used game)
+        sharedPrefs = getSharedPreferences(getString(R.string.sharedPrefs), Context.MODE_PRIVATE)
+        selectedGame = sharedPrefs.getInt("selectedGame", R.string.game_acnh)
         loadGameAssets(tabLayout.getTabAt(0))
 
         tabLayout.addOnTabSelectedListener(object : TabLayout.OnTabSelectedListener {
@@ -96,7 +101,6 @@ class CollectionActivity : AppCompatActivity(), SortDialogFragment.SortDialogLis
     override fun onDialogPositiveClick(dialog: DialogFragment, token: String, descending: Boolean) {
         viewAdapter.setRecords(recordset.applySort(token, descending))
     }
-
 
     private fun setFilterButtonsEnabled(enabled: Boolean) {
         isFilterSubmenuOpen = if (enabled) {
@@ -161,5 +165,9 @@ class CollectionActivity : AppCompatActivity(), SortDialogFragment.SortDialogLis
     private fun changeGame(game: Int) {
         selectedGame = game
         tabLayout.selectTab(tabLayout.getTabAt(0))
+        // Store selected game in persistent memory so this game is opened
+        // the next time the app is launched
+        // TODO: Also remember hemisphere, once we are allowed to change it
+        sharedPrefs.edit().putInt("selectedGame", game).apply()
     }
 }

--- a/app/src/main/java/com/dmonzonis/nookpendium/RecordListAdapter.kt
+++ b/app/src/main/java/com/dmonzonis/nookpendium/RecordListAdapter.kt
@@ -11,7 +11,7 @@ import kotlinx.android.synthetic.main.record_row.view.*
 class RecordListAdapter() :
     RecyclerView.Adapter<RecordListAdapter.RecordHolder>() {
 
-    private val prefsFilename = "com.dmonzonis.nookpedium.sharedPrefs"
+    private lateinit var prefsFilename: String
     private var sharedPrefs: SharedPreferences? = null
     private var records: List<Record> = listOf()
 
@@ -24,6 +24,7 @@ class RecordListAdapter() :
             .inflate(R.layout.record_row, parent, false)
 
         // Initialize shared preferences
+        prefsFilename = parent.context.getString(R.string.sharedPrefs)
         sharedPrefs = parent.context.getSharedPreferences(prefsFilename, 0)
 
         return RecordHolder(inflatedView)
@@ -52,10 +53,7 @@ class RecordListAdapter() :
         holder.checkBox.setOnClickListener {
             val state = holder.checkBox.isChecked
             record.captured = state
-            val editor: SharedPreferences.Editor? = sharedPrefs?.edit()
-            editor?.putBoolean(record.id, state)
-            editor?.apply()
+            sharedPrefs?.edit()?.putBoolean(record.id, state)?.apply()
         }
     }
-
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -25,4 +25,5 @@
     <string name="ascending">Ascending</string>
     <string name="descending">Descending</string>
     <string name="sort">Sort</string>
+    <string name="sharedPrefs">com.dmonzonis.nookpedium.sharedPrefs</string>
 </resources>


### PR DESCRIPTION
Instead of always opening ACNH data when the app launches, open data for
the last game that was used. So if the user was checking ACNL data last
time, next time he launches the app he will get ACNL instead of ACNH
(maybe he only owns ACNL and doesn't want to be switching games from the
burger menu each time he opens the app).